### PR TITLE
Regions fix

### DIFF
--- a/cordex/regions/_resources.py
+++ b/cordex/regions/_resources.py
@@ -9,7 +9,7 @@ def fetch_vg2500():
     """Fetch Germany Verwaltungsgebiete 1:2,500,000"""
     fname = retrieve(
         path=cache_url,
-        url="https://daten.gdz.bkg.bund.de/produkte/vg/vg2500/aktuell/vg2500_01-01.gk3.shape.zip",
+        url="https://daten.gdz.bkg.bund.de/produkte/vg/vg2500/2020/vg2500_01-01.gk3.shape.zip",
         known_hash="md5:5a1a86cd131decd9cf116dbfc1a66f17",
     )
     return fname

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 import cordex
 
@@ -32,17 +33,17 @@ import cordex
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-        "sphinx.ext.autodoc",
-        "sphinx.ext.autosummary",
-        "sphinx.ext.viewcode",
-        "sphinx.ext.extlinks",
-        "sphinx.ext.mathjax",
-        "sphinx.ext.napoleon",
-        "sphinxcontrib.mockautodoc",
-        "numpydoc",
-        "nbsphinx",
-        "nbsphinx_link",
-        "IPython.sphinxext.ipython_console_highlighting"
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib.mockautodoc",
+    "numpydoc",
+    "nbsphinx",
+    "nbsphinx_link",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
 
 
@@ -62,19 +63,19 @@ numpydoc_class_members_toctree = True
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Cordex Python Package'
+project = "Cordex Python Package"
 copyright = "2020, Lars Buntemeyer"
 author = "Lars Buntemeyer"
 
@@ -97,10 +98,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -111,10 +112,10 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-#html_theme = 'alabaster'
-html_theme = 'sphinx_rtd_theme'
+# html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
 
-html_logo = 'cordex_logo.png'
+html_logo = "cordex_logo.png"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -125,13 +126,13 @@ html_logo = 'cordex_logo.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'cordexdoc'
+htmlhelp_basename = "cordexdoc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -140,15 +141,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -158,9 +156,13 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'cordex.tex',
-     'Cordex Python Package Documentation',
-     'Lars Buntemeyer', 'manual'),
+    (
+        master_doc,
+        "cordex.tex",
+        "Cordex Python Package Documentation",
+        "Lars Buntemeyer",
+        "manual",
+    ),
 ]
 
 
@@ -168,11 +170,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'cordex',
-     'Cordex Python Package Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "cordex", "Cordex Python Package Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -181,16 +179,18 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'cordex',
-     'Cordex Python Package Documentation',
-     author,
-     'cordex',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "cordex",
+        "Cordex Python Package Documentation",
+        author,
+        "cordex",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
 add_module_names = False
-

--- a/examples/domain/domain.py
+++ b/examples/domain/domain.py
@@ -1,4 +1,4 @@
 from cordex import cordex_domain as dm
 
 
-eur11 = dm('EUR-11')
+eur11 = dm("EUR-11")

--- a/examples/domain/domain_create_high-res.py
+++ b/examples/domain/domain_create_high-res.py
@@ -8,16 +8,16 @@ import pandas as pd
 df = pd.DataFrame()
 
 # create high-res domains from cordex domains
-for short_name, domain in dm.domains('cordex').items():
-    print('domain: {}'.format(short_name))
+for short_name, domain in dm.domains("cordex").items():
+    print("domain: {}".format(short_name))
     if domain.dlon == 0.44:
         high_res = domain * 0.25
-        high_res.short_name = domain.short_name.split('-')[0]+'-11'
+        high_res.short_name = domain.short_name.split("-")[0] + "-11"
         high_res.long_name = domain.long_name
         high_res.region = domain.region
         df = df.append(high_res.to_pandas(), ignore_index=True)
 
 
-print(dm.table('cordex'))
+print(dm.table("cordex"))
 print(df)
-df.to_csv('cordex-high-res.csv', index=False, float_format='%g')
+df.to_csv("cordex-high-res.csv", index=False, float_format="%g")

--- a/examples/domain/domain_refinement.py
+++ b/examples/domain/domain_refinement.py
@@ -1,10 +1,9 @@
 from cordex import domain as dm
 
 
-
-eur44 = dm.domain('EUR-44')
-eur22 = dm.domain('EUR-22')
-eur11 = dm.domain('EUR-11')
+eur44 = dm.domain("EUR-44")
+eur22 = dm.domain("EUR-22")
+eur11 = dm.domain("EUR-11")
 
 # use of refinement funtion
 eur44_ref = eur44.refine(2.0)
@@ -13,8 +12,7 @@ eur44_ref = eur44.refine(2.0)
 print(eur22 == eur44_ref)
 
 # demonstrate simple domain math.
-print(eur22 == 0.5 * eur44 )
-print(eur11 == 0.25 * eur44 )
-print(eur11 == 0.5 * eur22 )
-print(eur44 == 4 * eur11 )
-
+print(eur22 == 0.5 * eur44)
+print(eur11 == 0.25 * eur44)
+print(eur11 == 0.5 * eur22)
+print(eur44 == 4 * eur11)

--- a/examples/esgf/access-esgf.py
+++ b/examples/esgf/access-esgf.py
@@ -2,18 +2,28 @@ import pandas as pd
 from cordex import esgf_access
 
 # Euro-Cordex search attributes
-attrs = {'project':'CORDEX', 'domain':'EUR-11'}
+attrs = {"project": "CORDEX", "domain": "EUR-11"}
 
 # create a datasets search result object
 results = esgf_access.datasets(attrs, verbose=True)
 
 # creates a pandas dataframe from dataset ids
-df = esgf_access.to_pandas(results, columns='CORDEX')
+df = esgf_access.to_pandas(results, columns="CORDEX")
 print(df)
-df.to_csv('euro-cordex-esgf.csv')
+df.to_csv("euro-cordex-esgf.csv")
 
 # regroup dataframe for excel output
-cordex_list = df.groupby(['institute', 'model_id', 'driving_model_id', 'experiment_id', 'member', 'frequency', 'domain'])['variable'].apply(list)
+cordex_list = df.groupby(
+    [
+        "institute",
+        "model_id",
+        "driving_model_id",
+        "experiment_id",
+        "member",
+        "frequency",
+        "domain",
+    ]
+)["variable"].apply(list)
 print(cordex_list)
 
-cordex_list.to_excel('cordex.xlsx')
+cordex_list.to_excel("cordex.xlsx")

--- a/examples/mask/mask-example.py
+++ b/examples/mask/mask-example.py
@@ -1,5 +1,3 @@
-
-
 import matplotlib.pyplot as plt
 
 from cordex.regions import _address
@@ -9,12 +7,12 @@ from cordex import domain as dm
 
 laender_mask = germany.VG2500.regionmask()
 laender_geodata = germany.VG2500.geodata()
-kreise_mask = germany.VG2500.regionmask('krs')
+kreise_mask = germany.VG2500.regionmask("krs")
 
 EUR11 = dm.domain("EUR-11")
 
 
-fig,ax = plt.subplots(figsize=(13,10))
+fig, ax = plt.subplots(figsize=(13, 10))
 fig = laender_mask.plot().get_figure()
 fig.savefig("laender.pdf")
 fig = kreise_mask.plot().get_figure()
@@ -25,10 +23,7 @@ EUR11_mask = EUR11.gridded_mask(laender_geodata)
 EUR11_mask.to_netcdf("EUR-11_laender_mask.nc")
 
 
-fig,ax = plt.subplots(figsize=(13,10))
-#fig = EUR11_mask.plot(xlim=(-10,0), ylim=(-4,5)).get_figure()
+fig, ax = plt.subplots(figsize=(13, 10))
+# fig = EUR11_mask.plot(xlim=(-10,0), ylim=(-4,5)).get_figure()
 fig = EUR11_mask.plot().get_figure()
 fig.savefig("EUR-11_laender_mask.pdf")
-
-
-

--- a/examples/plots/plot-REMO2015-domains.py
+++ b/examples/plots/plot-REMO2015-domains.py
@@ -9,35 +9,38 @@ from pyesgf.logon import LogonManager
 
 
 # logon to ESGF node
-print('logon to ESGF')
+print("logon to ESGF")
 lm = LogonManager()
 lm.logoff()
-lm.logon(hostname='esgf-data.dkrz.de', interactive=True, bootstrap=True)
-print('logged on: {}'.format(lm.is_logged_on()))
+lm.logon(hostname="esgf-data.dkrz.de", interactive=True, bootstrap=True)
+print("logged on: {}".format(lm.is_logged_on()))
 
 
 def plot_orog(filename, output):
-    """plots the orog variable to output file.
-    """
-    var = 'orog'
+    """plots the orog variable to output file."""
+    var = "orog"
     crxplt.contour2(filename, var, output)
 
 
-
 # search CORDEX project for REMO2015 fx orog variables
-conn = SearchConnection('http://esgf-data.dkrz.de/esg-search', distrib=False)
-ctx = conn.new_context(project='CORDEX', experiment='evaluation', time_frequency='fx', rcm_name='REMO2015', variable='orog')
+conn = SearchConnection("http://esgf-data.dkrz.de/esg-search", distrib=False)
+ctx = conn.new_context(
+    project="CORDEX",
+    experiment="evaluation",
+    time_frequency="fx",
+    rcm_name="REMO2015",
+    variable="orog",
+)
 result = ctx.search()
 
 # loop through search results of datasets
 for res in result:
     ctx = res.file_context()
-    domain = list(ctx.facet_counts['domain'].keys())[0]
-    print('domain: {}'.format(domain))
+    domain = list(ctx.facet_counts["domain"].keys())[0]
+    print("domain: {}".format(domain))
     # the dataset should contains only one files for fx variables
     dataset = ctx.search()
     filename = dataset[0].opendap_url
-    print('filename: {}'.format(filename))
-    output = '{}.png'.format(domain)
+    print("filename: {}".format(filename))
+    output = "{}.png".format(domain)
     plot_orog(filename, output)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,11 +19,11 @@ cdo
 urllib3
 cdo
 tqdm
-sphinx-rtd-theme
-sphinxcontrib-mockautodoc
+sphinx - rtd - theme
+sphinxcontrib - mockautodoc
 numpydoc
 nbsphinx
-nbsphinx-link
+nbsphinx - link
 ipython
 pooch
 #

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,13 @@
+
+import pytest
+import cordex as cx
+
+
+
+
+
+def test_germany():
+    mask = cx.regions.germany.geodataframe()
+
+def test_prudence():
+    mask = cx.regions.prudence.geodataframe

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,13 +1,10 @@
-
 import pytest
 import cordex as cx
 
 
-
-
-
 def test_germany():
     mask = cx.regions.germany.geodataframe()
+
 
 def test_prudence():
     mask = cx.regions.prudence.geodataframe


### PR DESCRIPTION
fixed path for download of germany regionsfile from `https://daten.gdz.bkg.bund.de/produkte/vg/vg2500`. The path now contains the year explicitly and not from the `aktuell` ordner to make sure, we have the same files downloaded...