### PR TITLE
added rounding of coordinate numbers

### DIFF
--- a/cordex/core/config.py
+++ b/cordex/core/config.py
@@ -1,2 +1,2 @@
 # number of digits for rounding coordinates due to issue https://github.com/euro-cordex/py-cordex/issues/60
-nround = 7
+nround = 14

--- a/cordex/core/config.py
+++ b/cordex/core/config.py
@@ -1,0 +1,2 @@
+# number of digits for rounding coordinates due to issue https://github.com/euro-cordex/py-cordex/issues/60
+nround = 7

--- a/cordex/core/domain.py
+++ b/cordex/core/domain.py
@@ -26,6 +26,8 @@ import xarray as xr
 from ..tables import domains
 from . import cf, utils
 
+nround = 7
+
 
 def domain_names(table_name=None):
     """Returns a list of short names of all availabe Cordex domains
@@ -377,8 +379,12 @@ def _grid_mapping(pollon, pollat, mapping_name=None):
 
 def _init_grid(nlon, nlat, dlon, dlat, ll_lon, ll_lat):
     """create coordinate arrays from lower left longitude and latitude"""
-    rlon = np.array([ll_lon + i * dlon for i in range(0, nlon)], dtype=np.float64)
-    rlat = np.array([ll_lat + i * dlat for i in range(0, nlat)], dtype=np.float64)
+    rlon = np.array(
+        [round(ll_lon + i * dlon, nround) for i in range(0, nlon)], dtype=np.float64
+    )
+    rlat = np.array(
+        [round(ll_lat + i * dlat, nround) for i in range(0, nlat)], dtype=np.float64
+    )
     return rlon, rlat
 
 

--- a/cordex/core/domain.py
+++ b/cordex/core/domain.py
@@ -25,8 +25,7 @@ import xarray as xr
 
 from ..tables import domains
 from . import cf, utils
-
-nround = 7
+from .config import nround
 
 
 def domain_names(table_name=None):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -15,7 +15,13 @@ v0.4.1 (Unreleased)
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
--  Added pre-commit hooks for Jupyter notebooks (including reformatting), added ``.zenodo.json`` (:pull:`59`).
+- Added pre-commit hooks for Jupyter notebooks (including reformatting), added ``.zenodo.json`` (:pull:`59`).
+
+Bug Fixes
+~~~~~~~~~
+
+- Fixed rounding errors for grid coordinates (:pull:`61`).
+
 
 
 v0.4.0 (29 April 2022)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -20,7 +20,7 @@ Internal Changes
 Bug Fixes
 ~~~~~~~~~
 
-- Fixed rounding errors for grid coordinates (:pull:`61`).
+- Fixed rounding errors for grid coordinates (:pull:`61`). This might have some influences on results, since coordinate values change up to single precision (which is irrelevant for CORDEX domains).
 
 
 

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -26,6 +26,9 @@ def test_domain_basic():
     assert "institution" in cx.cordex_domain("EUR-11", attrs="CORDEX").attrs
     assert "rotated_latitude_longitude" not in cx.cordex_domain("EUR-11i").data_vars
 
+    # ensure rounding errors fixed
+    assert np.float64(eur11.rlon.isel(rlon=34).data) == -24.635
+
 
 def test_cordex_regular():
     eur11i = cx.cordex_domain("EUR-11i")


### PR DESCRIPTION
According to #60, we can get rounding errors in the coordinate numbers. We now restrict precision of coordinates to 14 digits.

closes #60 

