### PR TITLE
update ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,35 +25,25 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        # Bookend python versions
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # python versions
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
       - name: Set environment variables
         run: |
           echo "CONDA_ENV_FILE=ci/requirements/environment.yml" >> $GITHUB_ENV
           echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: Cache conda
-        uses: actions/cache@v2
+      - name: Create conda environment
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{
-            hashFiles('ci/requirements/**.yml') }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          channels: conda-forge
-          channel-priority: strict
-          mamba-version: "*"
-          activate-environment: py-cordex-tests
-          auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
-          use-only-tar-bz2: true
-
-      - name: Install conda dependencies
-        run: |
-          mamba env update -f $CONDA_ENV_FILE
+          cache-downloads: true
+          cache-downloads-key: "${{runner.os}}-${{runner.arch}}-py${{matrix.python-version}}-${{hashFiles(env.CONDA_ENV_FILE)}}"
+          micromamba-version: 'latest'
+          environment-file: ci/requirements/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
       - name: Install py-cordex
         run: |
           python -m pip install --no-deps -e .
@@ -65,20 +55,14 @@ jobs:
         run: |
           python -c "import cordex"
       - name: Run tests
-        run: python -m pytest
-          --cov=cordex
+        timeout-minutes: 5
+        run: python -u -m pytest
+          --cov=regionmask
           --cov-report=xml
           --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: Test results for ${{ runner.os }}-${{ matrix.python-version }}
-          path: test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
-
       - name: Upload code coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -22,38 +22,26 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        # Bookend python versions
+        # python versions
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags.
-      - name: Set environment variables
-        run: |
-          echo "CONDA_ENV_FILE=ci/requirements/environment.yml" >> $GITHUB_ENV
-          echo "PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-      - name: Cache conda
-        uses: actions/cache@v2
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-py${{ matrix.python-version }}-${{ hashFiles('ci/requirements/**.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-conda-py${{ matrix.python-version }}-
-            ${{ runner.os }}-
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          channels: conda-forge
-          channel-priority: strict
-          mamba-version: "*"
-          activate-environment: py-cordex-tests
-          auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
-          use-only-tar-bz2: true
 
-      - name: Install conda dependencies
-        run: |
-          mamba env update -f $CONDA_ENV_FILE
-          mamba install black isort flake8
+      - name: Create conda environment
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-name: py-cordex-linting
+          micromamba-version: 'latest'
+          environment-file: ci/requirements/environment.yml
+          extra-specs: |
+            python=${{ matrix.python-version }}
+            black
+            isort
+            flake8
+          channels: conda-forge
+
       - name: Install py-cordex
         run: |
           python -m pip install --no-deps -e .
@@ -61,7 +49,7 @@ jobs:
         run: |
           conda info -a
           conda list
-      - name: Import py-cordex
+      - name: Import cordex
         run: |
           python -c "import cordex"
       - name: isort

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - cartopy
   - matplotlib-base
-  - numpy
+  - numpy<1.24 # fixed until next cmor release
   - pooch
   - regionmask
   - setuptools

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,7 +11,15 @@ What's New
 v0.5.0 (Unreleased)
 -------------------
 
+New Features
+~~~~~~~~~~~~
+
 - Cmorization module from ``pyremo.cmor`` has been moved upstream into ``cordex.cmor``. A new cmorization funcion :py:meth:`cmor.cmorize_variable` now allows for easy cmorization using the archive specifications included in ``py-cordex`` (:pull:`68`, :pull:`74`, :pull:`76`, :pull:`77`).
+
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+- Updated CI pipeline (:pull:`83`).
 
 
 v0.4.1 (23 June 2022)
@@ -30,7 +38,6 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixed rounding errors for grid coordinates (:pull:`61`). This might have some influence on results, since coordinate values might change to more exact values.
-
 
 
 v0.4.0 (29 April 2022)

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,11 +41,16 @@ filterwarnings =
 
 [flake8]
 ignore=
-    E203 # whitespace before ':' - doesn't work well with black
-    E402 # module level import not at top of file
-    E501 # line too long - let black worry about that
-    E731 # do not assign a lambda expression, use a def
-    W503 # line break before binary operator
+    # whitespace before ':' - doesn't work well with black
+    E203
+    # module level import not at top of file
+    E402
+    # line too long - let black worry about that
+    E501
+    # do not assign a lambda expression, use a def
+    E731
+    # line break before binary operator
+    W503
 exclude=
     build
     docs


### PR DESCRIPTION
update ci workflows, fixes `numpy<1.24` until latest cmor release.