### PR TITLE
keyword deprecations

### DIFF
--- a/cordex/cf.py
+++ b/cordex/cf.py
@@ -84,3 +84,5 @@ DEFAULT_CORDEX_ATTRS = {
     "realization": 0,
     "cmor_version": "",
 }
+
+grid_mapping_dtype = np.int32

--- a/cordex/domain.py
+++ b/cordex/domain.py
@@ -96,8 +96,8 @@ def cordex_domain(
 
     Returns
     -------
-    Dataset : xarray.core.Dataset
-        Dataset containing the coordinates.
+    Grid : xr.Dataset
+        Dataset containing a CORDEX grid.
 
     Example
     -------
@@ -185,7 +185,6 @@ def create_dataset(
             of the ``bounds`` parameter, and will be removed in a future
             version.
 
-
     attrs: str or dict
         Global attributes that should be added to the dataset. If `attrs='CORDEX'`
         a set of standard CF global attributes.
@@ -196,6 +195,11 @@ def create_dataset(
         Add spatial bounds to longitude and latitude coordinates.
 
         .. versionadded:: v0.5.0
+
+    Returns
+    -------
+    Grid : Dataset
+        Dataset containing a CORDEX grid.
 
     """
     if add_vertices is True:
@@ -298,17 +302,7 @@ def _get_regular_dataset(
     ds.lat.attrs["axis"] = "Y"
 
     if bounds is True:
-        from cartopy import crs as ccrs
-
-        pole = (
-            ds[mapping_name].grid_north_pole_longitude,
-            ds[mapping_name].grid_north_pole_latitude,
-        )
-        # v = vertices(ds, ccrs.RotatedPole(*pole))
-        v = vertices(ds.rlon, ds.rlat, ccrs.RotatedPole(*pole))
-        ds = xr.merge([ds, v])
-        ds[cf.LON_NAME].attrs["bounds"] = cf.LON_BOUNDS
-        ds[cf.LAT_NAME].attrs["bounds"] = cf.LAT_BOUNDS
+        ds = ds.cf.add_bounds(("lon", "lat"))
 
     if dummy is not None:
         ds = _add_dummy(ds, dummy)

--- a/cordex/transform.py
+++ b/cordex/transform.py
@@ -269,7 +269,7 @@ def grid_mapping(pollon, pollat, mapping_name=None):
     """creates a grid mapping DataArray object"""
     if mapping_name is None:
         mapping_name = cf.DEFAULT_MAPPING_NCVAR
-    da = xr.DataArray(np.zeros((), dtype=np.int32))
+    da = xr.DataArray(np.zeros((), dtype=cf.grid_mapping_dtype))
     attrs = cf.mapping.copy()
     attrs["grid_north_pole_longitude"] = pollon
     attrs["grid_north_pole_latitude"] = pollat

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -27,6 +27,7 @@ Internal Changes
 - Moved core modules (:pull:`87`).
 - Added ``CITATION.cff`` (:pull:`87`).
 - Updated documentation environment for python 3.10 (:pull:`89`).
+- ``add_vertices`` keyword is deprecated in favour of ``bounds`` keyword in :py:meth:`cordex_domain` and :py:meth:`create_dataset` (:pull:`101`).
 
 
 v0.4.1 (23 June 2022)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -18,6 +18,11 @@ New Features
 
 - Added :py:meth:`transform` and :py:meth:`transform_coords` in favour of deprecated :py:meth:`map_crs` and :py:meth:`rotated_coord_transform`. Dropped ``cartopy`` dependency in favour of ``pyproj`` (:pull:`71`).
 
+Deprecations
+~~~~~~~~~~~~
+
+- ``add_vertices`` keyword is deprecated in favour of ``bounds`` keyword in :py:meth:`cordex_domain` and :py:meth:`create_dataset` (:pull:`101`).
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
@@ -27,7 +32,8 @@ Internal Changes
 - Moved core modules (:pull:`87`).
 - Added ``CITATION.cff`` (:pull:`87`).
 - Updated documentation environment for python 3.10 (:pull:`89`).
-- ``add_vertices`` keyword is deprecated in favour of ``bounds`` keyword in :py:meth:`cordex_domain` and :py:meth:`create_dataset` (:pull:`101`).
+- Use ``cf-xarray`` for adding bounds to regular datasets (:pull:`101`).
+
 
 
 v0.4.1 (23 June 2022)


### PR DESCRIPTION
closes #98
closes #99 

`add_vertices` is deprecated in favour of `bounds` keyword in `cx.cordex_domain`. For regular grids, we use `cf-xarray` to add latitude and longitude bounds.