### PR TITLE
use add_time_bounds from pyhomogenize

### DIFF
--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -371,6 +371,7 @@ def _add_time_bounds(ds, cf_freq):
         ds = _add_month_bounds(ds)
     else:
         from pyhomogenize import time_control
+
         ds = time_control(ds).add_time_bounds(frequency=cf_freq).ds
     return ds
 

--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -370,13 +370,8 @@ def _add_time_bounds(ds, cf_freq):
     if cf_freq == "mon":
         ds = _add_month_bounds(ds)
     else:
-        try:
-            ds = ds.convert_calendar(ds.time.dt.calendar).cf.add_bounds("time")
-        except Exception:
-            # wait for cftime arithemtics in xarry here:
-            warn("could not add time bounds.")
-    ds[time_bounds_name].encoding = ds.time.encoding
-    ds.time.attrs.update({"bounds": time_bounds_name})
+        from pyhomogenize import time_control
+        ds = time_control(ds).add_time_bounds(frequency=cf_freq).ds
     return ds
 
 


### PR DESCRIPTION
Hi Lars,
ich hab die time_bnds aus [`pyhomogenize`](https://github.com/ludwiglierhammer/pyhomogenize) eingebaut (das kann man auch mit `pip` installieren). In dem Paket hab ich alles gesammelt, was so mit der Zeitachse zu tun hat. Ich verwende es auch zum Berechen der Klimaindizes. Ich denke da, ist auch für `py-cordex` noch einiges nützliches dabei. Das könne wir ja mal, wenn du im Büro bist und Zeit hast, besprechen.
VG, Ludwig 