### PR TITLE
updated CORDEX cmor table path for CMIP6

### DIFF
--- a/cordex/tables/__init__.py
+++ b/cordex/tables/__init__.py
@@ -57,6 +57,12 @@ def cordex_cmor_table(table, table_dir=None):
     filename : str
         Filepath to the cordex cmor table.
     """
+    # make sure these are fetched because cmor
+    # requires them silently
+    fetch_cordex_cmor_table("CORDEX_coordinate")
+    fetch_cordex_cmor_table("CORDEX_grids")
+    fetch_cordex_cmor_table("CORDEX_formula_terms")
+
     return fetch_cordex_cmor_table(table)
 
 

--- a/cordex/tables/_resources.py
+++ b/cordex/tables/_resources.py
@@ -64,7 +64,9 @@ cmor_tables_inpath = str(pooch.os_cache("cmor-tables"))
 
 def fetch_cordex_cmor_table(table):
     return retrieve_cmor_table(
-        table, url="https://github.com/euro-cordex/cordex-cmor-tables/raw/main/Tables"
+        # table, url="https://github.com/euro-cordex/cordex-cmor-tables/raw/main/Tables"
+        table,
+        url="https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/raw/main/Tables",
     )
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -23,7 +23,9 @@ New Features
 Breaking Changes
 ~~~~~~~~~~~~~~~~
 
-``nan`` values in domain tables are replace with ``None``. That means in case you retrive domain information with :py:meth:`domain_info` for a regular grid, ``pollon`` and ``pollat`` will now be ``None`` instead of ``nan`` (:issue:`107`, :pull:`105`).
+* The standard cmor tables are now fetched from the development `repository <https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/tree/main/Tables>`_ (:pull:`116`).
+
+* ``nan`` values in domain tables are replace with ``None``. That means in case you retrive domain information with :py:meth:`domain_info` for a regular grid, ``pollon`` and ``pollat`` will now be ``None`` instead of ``nan`` (:issue:`107`, :pull:`105`).
 
 Deprecations
 ~~~~~~~~~~~~

--- a/tests/test_cmor.py
+++ b/tests/test_cmor.py
@@ -166,9 +166,9 @@ def test_cmorizer_fx():
         ds,
         "orog",
         mapping_table={"orog": {"varname": "topo"}},
-        cmor_table=cx.tables.cmip6_cmor_table("CMIP6_fx"),
+        cmor_table=cx.tables.cordex_cmor_table("CORDEX_fx"),
         dataset_table=cx.tables.cordex_cmor_table("CORDEX_remo_example"),
-        grids_table=cx.tables.cmip6_cmor_table("CMIP6_grids"),
+        grids_table=cx.tables.cordex_cmor_table("CORDEX_grids"),
         CORDEX_domain="EUR-11",
         time_units=None,
         allow_units_convert=True,
@@ -185,9 +185,9 @@ def test_cmorizer_mon():
         ds,
         "tas",
         mapping_table={"tas": {"varname": "TEMP2"}},
-        cmor_table=cx.tables.cmip6_cmor_table("CMIP6_Amon"),
+        cmor_table=cx.tables.cordex_cmor_table("CORDEX_mon"),
         dataset_table=cx.tables.cordex_cmor_table("CORDEX_remo_example"),
-        grids_table=cx.tables.cmip6_cmor_table("CMIP6_grids"),
+        grids_table=cx.tables.cordex_cmor_table("CORDEX_grids"),
         CORDEX_domain="EUR-11",
         time_units=None,
         allow_units_convert=True,
@@ -197,7 +197,7 @@ def test_cmorizer_mon():
     assert "tas" in output
 
 
-@pytest.mark.parametrize("table, tdim", [("CMIP6_day", 3), ("CMIP6_3hr", 17)])
+@pytest.mark.parametrize("table, tdim", [("CORDEX_day", 3), ("CORDEX_1hr", 49)])
 def test_cmorizer_subdaily(table, tdim):
     ds = cx.tutorial.open_dataset("remo_EUR-11_TEMP2_1hr")
     eur11 = cx.cordex_domain("EUR-11")
@@ -206,9 +206,9 @@ def test_cmorizer_subdaily(table, tdim):
         ds,
         "tas",
         mapping_table={"tas": {"varname": "TEMP2"}},
-        cmor_table=cx.tables.cmip6_cmor_table(table),
+        cmor_table=cx.tables.cordex_cmor_table(table),
         dataset_table=cx.tables.cordex_cmor_table("CORDEX_remo_example"),
-        grids_table=cx.tables.cmip6_cmor_table("CMIP6_grids"),
+        grids_table=cx.tables.cordex_cmor_table("CORDEX_grids"),
         CORDEX_domain="EUR-11",
         time_units=None,
         allow_units_convert=True,


### PR DESCRIPTION
closes #100 

Updated fetch url for [standard CORDEX cmor tables](https://github.com/WCRP-CORDEX/cordex-cmip6-cmor-tables/tree/main/Tables).