### PR TITLE
ensure upper case time offsets for now

### DIFF
--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -398,10 +398,12 @@ def _add_time_bounds(ds, cf_freq):
 
 def _adjust_frequency(ds, cf_freq, input_freq=None, time_cell_method=None):
     if input_freq is None and "time" in ds.coords:
-        input_freq = xr.infer_freq(ds.time).upper()
+        input_freq = xr.infer_freq(ds.time)
     if input_freq is None:
         warn("Could not determine frequency of input data, will assume it is correct.")
         return ds
+    else:
+        input_freq = input_freq.upper()
     pd_freq = freq_map[cf_freq]
     if pd_freq != input_freq:
         warn("resampling input data from {} to {}".format(input_freq, pd_freq))

--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -346,7 +346,7 @@ def _rewrite_time_axis(ds, freq=None, calendar=None):
     ds = ds.copy(deep=False)
     pd_freq = freq_map.get(freq, None)
     if freq is None:
-        pd_freq = xr.infer_freq(ds.time)
+        pd_freq = xr.infer_freq(ds.time).upper()
     if calendar is None:
         calendar = ds.time.dt.calendar
     start = ds.time.data[0]
@@ -398,7 +398,7 @@ def _add_time_bounds(ds, cf_freq):
 
 def _adjust_frequency(ds, cf_freq, input_freq=None, time_cell_method=None):
     if input_freq is None and "time" in ds.coords:
-        input_freq = xr.infer_freq(ds.time)
+        input_freq = xr.infer_freq(ds.time).upper()
     if input_freq is None:
         warn("Could not determine frequency of input data, will assume it is correct.")
         return ds

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -6,7 +6,12 @@ What's New
 UNRELEASED
 ----------
 
-Bugfixes
+Internal Changes
+~~~~~~~~~~~~~~~~
+
+- Stick to upper case pandas time offset strings for now (:pull:`198`).
+
+  Bugfixes
 ~~~~~~~~
 
 - Fix ``flox`` method in cmor module (:pull:`197`).


### PR DESCRIPTION
pandas will deprecate some upper case time offsets in the future. To ensure compatibility with cftime and cmor frequencies, we stick to uppercase for now.