### PR TITLE
fix bounds bug

### DIFF
--- a/cordex/transform.py
+++ b/cordex/transform.py
@@ -340,8 +340,8 @@ def transform_bounds(
         ds.cf["Y"].dims[0], ds.cf["X"].dims[0], bnds_dim
     )
 
-    ds[ds.cf["longitude"].name].attrs["bounds"] = cf.LON_BOUNDS
-    ds[ds.cf["latitude"].name].attrs["bounds"] = cf.LAT_BOUNDS
+    ds[ds.cf["longitude"].name].attrs["bounds"] = trg_dims[0]
+    ds[ds.cf["latitude"].name].attrs["bounds"] = trg_dims[1]
 
     return ds.assign_coords(
         {

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,7 +17,12 @@ New Features
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
-- Update of API documentation in accessor (:pull:`308`).
+- Fix coordinate bounds attribute in :py:meth:`transform_bounds` (:pull:`314`).
+
+Bugfixes
+~~~~~~~~
+
+- Fixed deprecated ``xarray`` keywords (:pull:`273`).
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This pull request includes a change to the `transform_bounds` function in the `cordex/transform.py` file. The change modifies the attributes for longitude and latitude bounds to use the target dimensions instead of constant values.

* [`cordex/transform.py`](diffhunk://#diff-5269422ec4c79704c3be74916b9bf2b48b842188f68163ab3ceb9c7503a25b5aL343-R344): Updated the `transform_bounds` function to set the longitude and latitude bounds attributes to `trg_dims[0]` and `trg_dims[1]` respectively, instead of `cf.LON_BOUNDS` and `cf.LAT_BOUNDS`.