### PR TITLE
fix x y in accessor map

### DIFF
--- a/cordex/accessor.py
+++ b/cordex/accessor.py
@@ -186,13 +186,20 @@ class CordexAccessor:
 
         obj = self._obj
 
+        try:
+            x = obj.cf["X"]
+            y = obj.cf["Y"]
+        except KeyError:
+            x = obj.rlon
+            y = obj.rlat
+
         mapping = obj.cf["grid_mapping"]
         pole = (
             mapping.grid_north_pole_longitude,
             mapping.grid_north_pole_latitude,
         )
         central_longitude = 0.0
-        if obj.cf["X"].min() > 0.0:
+        if x.min() > 0.0:
             central_longitude = 180.0
 
         transform = ccrs.RotatedPole(*pole, central_rotated_longitude=central_longitude)
@@ -214,10 +221,10 @@ class CordexAccessor:
         )
         ax.set_extent(
             [
-                obj.rlon.min() - central_longitude,
-                obj.rlon.max() - central_longitude,
-                obj.rlat.min(),
-                obj.rlat.max(),
+                x.min() - central_longitude,
+                x.max() - central_longitude,
+                y.min(),
+                y.max(),
             ],
             crs=transform,
         )

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,6 +22,7 @@ Internal Changes
 Bugfixes
 ~~~~~~~~
 
+- Fixed :py:meth:`Dataset.cx.map` for arbitrary x-y axis names (:pull:`324`).
 - Fixed deprecated ``xarray`` keywords (:pull:`273`).
 
 Breaking Changes


### PR DESCRIPTION
This pull request refactors the `map` method in `cordex/accessor.py` to improve code readability and handle cases where `cf["X"]` or `cf["Y"]` keys are not present. The changes ensure fallback to `rlon` and `rlat` attributes when necessary and replace repeated calls to `obj.cf` with local variables for better clarity and efficiency.