### PR TITLE
added cmor compression options

### DIFF
--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -333,17 +333,19 @@ def _cmor_write(da, table_id, cmorTime, cmorZ, cmorGrid, file_name=True):
         if kwarg in da.attrs:
             cmor_var_kwargs[kwarg] = da.attrs[kwarg]
 
-    cmor_var = cmor.variable(
+    var_id = cmor.variable(
         table_entry=da.name, units=da.units, axis_ids=coords, **cmor_var_kwargs
     )
+
+    cmor.set_deflate(var_id, **options["compression"])
 
     if "time" in da.coords:
         ntimes_passed = da.time.size
     else:
         ntimes_passed = None
-    cmor.write(cmor_var, da.to_numpy(), ntimes_passed=ntimes_passed)
+    cmor.write(var_id, da.to_numpy(), ntimes_passed=ntimes_passed)
 
-    return cmor.close(cmor_var, file_name=file_name)
+    return cmor.close(var_id, file_name=file_name)
 
 
 def _units_convert(da, cf_units, format=None):

--- a/cordex/cmor/config.py
+++ b/cordex/cmor/config.py
@@ -7,6 +7,8 @@ options = {
     "exit_control": "CMOR_NORMAL",
     "resample_kwargs": {"closed": "left"},
     "earth_radius": 6371229.0,  # in meters
+    "compression": {"shuffle": True, "deflate": True, "deflate_level": 1},
+    # "compression": {"shuffle": False, "deflate": True, "deflate_level": 1},
 }
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -6,9 +6,13 @@ What's new
 UNRELEASED
 ----------
 
+This release changes default compression options in ``cordex.cmor`` to ``{"shuffle": True, "deflate": True, "deflate_level": 1}`` to be
+compliant with the `CORDEX-CMIP6 archive specs <https://zenodo.org/records/15047096>`_. If you need to set the former options, use ``cordex.cmor.set_options(compression={"shuffle": False, "deflate": True, "deflate_level": 1})``.
+
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Added cmor deflate options (:pull:`360`).
 - Update pandas time offset strings (:pull:`350`).
 
 v0.10.1 (02 June 2025)


### PR DESCRIPTION
This pull request updates the CMOR writing process to support compression settings and makes compression configurable via the global options. The main changes are focused on enabling deflate compression for output files and ensuring the compression parameters are passed correctly to the CMOR library.

**Compression support and configuration:**

* Added a `"compression"` entry to the global options in `cordex/cmor/config.py`, allowing shuffle, deflate, and deflate level to be set for CMOR output files.
* Updated `_cmor_write` in `cordex/cmor/cmor.py` to call `cmor.set_deflate` with the compression options before writing data, enabling compression for each variable.

**Code consistency and naming:**

* Changed the variable name from `cmor_var` to `var_id` in `_cmor_write` for consistency with the CMOR library's API.
* Updated references to the variable identifier throughout `_cmor_write` to use `var_id`, including in calls to `cmor.write` and `cmor.close`.