### PR TITLE
Improve domain guessing with missing and zero valued coordinates

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -9,6 +9,11 @@
       "affiliation": "Netherlands eScience Center, Netherlands",
       "name": "Bouwe Andela",
       "orcid": "0000-0001-9005-8940"
+    },
+    {
+      "affiliation": "Middle East Technical University, Institute of Marine Sciences",
+      "name": "Ali Osman Acar",
+      "orcid": "0000-0002-9813-8387"
     }
   ],
   "keywords": [

--- a/cordex/accessor.py
+++ b/cordex/accessor.py
@@ -83,12 +83,18 @@ def _guess_domain(ds, tables=None):
         )
     filt = tables
     for k, v in info.items():
+        if k in ["ur_lon", "ur_lat"]:
+            continue
         if filt.empty:
             return None
-        if v:
-            filt = filt[np.isclose(filt[k], v)]
+        try:
+            missing = np.isnan(v)
+        except TypeError:
+            missing = v is None
+        if missing:
+            filt = filt[filt[k].isna()]
         else:
-            filt = filt[np.isnan(filt[k])]  # | filt[k] is None]
+            filt = filt[np.isclose(filt[k], v)]
     # reset index and convert to dict
     return filt.reset_index().iloc[0].replace(np.nan, None).to_dict()
 

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -73,7 +73,10 @@ def test_rewrite_coords(domain_id):
     np.testing.assert_array_equal(rewritten_data.rlat, grid.rlat)
     xr.testing.assert_identical(rewritten_data, grid)
 
-@pytest.mark.parametrize("domain_id",["ARC-44", "ARC-11", "CEU-0275", "CAS-44i", "MED-44i"])
+
+@pytest.mark.parametrize(
+    "domain_id", ["ARC-44", "ARC-11", "CEU-0275", "CAS-44i", "MED-44i"]
+)
 def test_guess_info_edge_cases(domain_id):
     ds = xr.decode_cf(cx.cordex_domain(domain_id, dummy=True), decode_coords="all")
     info = cx.domain_info(domain_id)

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -72,3 +72,13 @@ def test_rewrite_coords(domain_id):
     np.testing.assert_array_equal(rewritten_data.rlon, grid.rlon)
     np.testing.assert_array_equal(rewritten_data.rlat, grid.rlat)
     xr.testing.assert_identical(rewritten_data, grid)
+
+@pytest.mark.parametrize("domain_id",["ARC-44", "ARC-11", "CEU-0275", "CAS-44i", "MED-44i"])
+def test_guess_info_edge_cases(domain_id):
+    ds = xr.decode_cf(cx.cordex_domain(domain_id, dummy=True), decode_coords="all")
+    info = cx.domain_info(domain_id)
+
+    assert ds.cx.guess() == info
+
+    del ds.attrs["CORDEX_domain"]
+    assert ds.cx.domain_id == domain_id


### PR DESCRIPTION
Fixes #410 
The previous logic used truthiness checks, which treated `0.0` as missing. 
I also skip `ur_lon` and `ur_lat` while guessing since they are derived