### PR TITLE
fix and configure ruff issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,14 @@ repos:
     - id: check-json
     - id: end-of-file-fixer
     - id: trailing-whitespace
-
+    
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.16.2'
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.5.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,6 @@ repos:
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.5.1
-    hooks:
-    - id: black
-
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.9.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: check-json
     - id: end-of-file-fixer
     - id: trailing-whitespace
-    
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: 'v0.16.2'

--- a/cordex/cli.py
+++ b/cordex/cli.py
@@ -11,7 +11,7 @@ def main():
     args = parser.parse_args()
 
     print("Arguments: " + str(args._))
-    print("Replace this message by putting your code into " "cordex.cli.main")
+    print("Replace this message by putting your code into cordex.cli.main")
     return 0
 
 

--- a/cordex/cmor/cmor.py
+++ b/cordex/cmor/cmor.py
@@ -137,7 +137,7 @@ def _load_table(table):
 
 def _setup(dataset_table, mip_table, grids_table=None, inpath="."):
     if grids_table is None:
-        grids_table = f'{options["table_prefix"]}_grids.json'
+        grids_table = f"{options['table_prefix']}_grids.json"
     cmor.setup(
         inpath,
         set_verbosity=cmor.CMOR_NORMAL,

--- a/cordex/utils.py
+++ b/cordex/utils.py
@@ -28,9 +28,8 @@ def _cell_area(ds, R=6371000):
         np.deg2rad(
             ds.cf[c]
             # pad values to account for differentiation
-            .pad({ds.cf[c].dims[0]: (1, 0)}, mode="reflect", reflect_type="odd").diff(
-                ds.cf[c].dims[0]
-            )
+            .pad({ds.cf[c].dims[0]: (1, 0)}, mode="reflect", reflect_type="odd")
+            .diff(ds.cf[c].dims[0])
         )
         for c in ("X", "Y")
     )

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -9,6 +9,7 @@ UNRELEASED
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Fix and configure ruff issues (:pull:`429`).
 - Add proj dependency to environment.yml (:pull:`430`).
 - Update Read the Docs configuration for Ubuntu and Python (:pull:`423`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,20 +48,23 @@ fallback_version = "999"
 version_scheme = "no-guess-dev"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [
     ".eggs",
-    "docs",
+    "doc",
 ]
+
+[tool.ruff.lint]
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
-[lint]
 ignore = [
     "E402",
     "E501",
     "E731",
+    "B018",
+    "B015",
 ]
 select = [
     # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ target-version = "py311"
 builtins = ["ellipsis"]
 exclude = [
     ".eggs",
-    "doc",
+    "docs",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Updated target version for ruff to Python 3.11 and modified exclusions.